### PR TITLE
Change 'userId' to '_id' in users and stories put handlers to fix "mod on _id not allowed"

### DIFF
--- a/features/stories/index.js
+++ b/features/stories/index.js
@@ -27,7 +27,7 @@ app.get('/:id', function(req, res) {
 });
 
 app.put('/:id', function(req, res) {
-  Story.update({_id: req.params.id, userId: req.user.sub}, _.omit(req.body, 'userId'), function(err, story){
+  Story.update({_id: req.params.id, userId: req.user.sub}, _.omit(req.body, '_id'), function(err, story){
       if (err) {
         res.status(400).send(err);
       } else {

--- a/features/users/index.js
+++ b/features/users/index.js
@@ -27,7 +27,7 @@ app.get('/:id', function(req, res) {
 });
 
 app.put('/:id', function(req, res) {
-  User.update({_id: req.params.id, userId: req.user.sub}, _.omit(req.body, 'userId'), function(err, user){
+  User.update({_id: req.params.id, userId: req.user.sub}, _.omit(req.body, '_id'), function(err, user){
       if (err) {
         res.status(400).send(err);
       } else {


### PR DESCRIPTION
```
_.omit(req.body, 'userId')
```

to:
    _.omit(req.body, '_id')
on
     app.put('/:id', ...)
route handlers of both stories/index.js and users/index.js in order to fix to fix MongoDb "mod on _id not allowed" error.
